### PR TITLE
exit 1 on cookie failure

### DIFF
--- a/intel_watcher.py
+++ b/intel_watcher.py
@@ -130,7 +130,7 @@ if __name__ == "__main__":
             }
             result = requests.post(config.wh_url, json=data)
             print(result)
-        sys.exit()
+        sys.exit(1)
     else:
         print("Cookie works!")
 


### PR DESCRIPTION
The program should exit non-zero on cookie failure because it didn't terminate successfully in that case.

This can then be used by external scripts, for example when running intelwatcher in a bash script, to determine further external action (send a mail, do not run stopwatcher, et cetera).